### PR TITLE
use msgpack for serialization of scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+jerakia/
+test/

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem "jerakia-client"
 gem "rake"
+gem "msgpack"
 
 if File.exists?('jerakia/Gemfile')
   eval_gemfile('jerakia/Gemfile')

--- a/lib/hiera/backend/jerakia_backend.rb
+++ b/lib/hiera/backend/jerakia_backend.rb
@@ -1,5 +1,6 @@
 require 'puppet'
 require 'puppet/resource'
+require 'msgpack'
 
 class Hiera
   module Backend
@@ -38,9 +39,9 @@ class Hiera
 
         metadata = {}
         if scope.is_a?(Hash)
-          metadata = scope.reject { |_k, v| v.is_a?(Puppet::Resource) }
+          metadata = MessagePack.unpack(scope.to_msgpack)
         else
-          metadata = scope.real.to_hash.reject { |_k, v| v.is_a?(Puppet::Resource) }
+          metadata = MessagePack.unpack(scope.real.to_hash.to_msgpack)
         end
 
         request = Jerakia::Request.new(


### PR DESCRIPTION

This is to ensure (properly) that objects such as those of the `Puppet::Resource` type don't get passed in the metadata request into Jerakia - this was fixed previously but not well enough, since things like metaparameters can be in arrays - by serializing and deserializing using msgpack we effectively 'clean' the metadata.

FYI @ruriky
